### PR TITLE
fix: Fix group controller & expiration of secret key

### DIFF
--- a/config/secretkey.js
+++ b/config/secretkey.js
@@ -2,6 +2,5 @@ module.exports = {
   secretKey: process.env.SECRET_KEY,
   option: {
     algorithm: "HS256",
-    expiresIn: "30m",
   },
 };

--- a/controllers/groupController.js
+++ b/controllers/groupController.js
@@ -5,6 +5,27 @@ const Group = require("../models/Group");
 const Todo = require("../models/Todo");
 const catchAsync = require("../utils/catchAsync");
 
+exports.getGroup = catchAsync(async (req, res, next) => {
+  const { groupId } = req.params;
+
+  if (!mongoose.isValidObjectId(groupId)) {
+    return res.json({
+      result: "error",
+      error: {
+        message: "유효하지 않은 그룹입니다.",
+        status: 400,
+      },
+    });
+  }
+
+  const group = await Group.findById(groupId).populate("members").populate("todos").lean();
+
+  return res.json({
+    result: "success",
+    data: { group },
+  });
+});
+
 exports.createGroup = catchAsync(async (req, res, next) => {
   const { title } = req.body;
 

--- a/controllers/mainController.js
+++ b/controllers/mainController.js
@@ -1,3 +1,5 @@
+const mongoose = require("mongoose");
+
 const Todo = require("../models/Todo");
 const User = require("../models/User");
 const Group = require("../models/Group");
@@ -5,6 +7,16 @@ const catchAsync = require("../utils/catchAsync");
 
 exports.getGroupsOrPersonalTodos = catchAsync(async (req, res, next) => {
   const { _id } = req.user;
+
+  if (!mongoose.isValidObjectId(_id)) {
+    return res.json({
+      result: "error",
+      error: {
+        message: "유효하지 않은 유저입니다.",
+        status: 400,
+      },
+    });
+  }
 
   const { name, level, experience, personalTodos, group } = await User.findById(_id).lean();
   const currentUsersTodo = await Todo.find().in("_id", [personalTodos]).lean();

--- a/controllers/todoController.js
+++ b/controllers/todoController.js
@@ -5,27 +5,6 @@ const Group = require("../models/Group");
 const Todo = require("../models/Todo");
 const catchAsync = require("../utils/catchAsync");
 
-exports.getGroupTodos = catchAsync(async (req, res, next) => {
-  const { groupId } = req.params;
-
-  if (!mongoose.isValidObjectId(groupId)) {
-    return res.json({
-      result: "error",
-      error: {
-        message: "유효하지 않은 그룹입니다.",
-        status: 400,
-      },
-    });
-  }
-
-  const group = await Group.findById(groupId);
-
-  return res.json({
-    result: "success",
-    data: group.todos,
-  });
-});
-
 exports.createTodo = catchAsync(async (req, res, next) => {
   const { title, content } = req.body;
 

--- a/routes/group.js
+++ b/routes/group.js
@@ -6,11 +6,11 @@ const TodoController = require("../controllers/todoController");
 
 const router = express.Router();
 
+router.get("/:groupId", isLoggedIn, GroupController.getGroup);
 router.post("/", isLoggedIn, GroupController.createGroup);
 router.patch("/:groupId", isLoggedIn, GroupController.updateGroup);
 router.delete("/:groupId", isLoggedIn, GroupController.deleteGroup);
 
-router.get("/:groupId/todos", isLoggedIn, TodoController.getGroupTodos);
 router.post("/:groupId/todos", isLoggedIn, TodoController.createTodo);
 router.patch("/:groupId/todos/:todoId", isLoggedIn, TodoController.updateTodo);
 router.delete("/:groupId/todos/:todoId", isLoggedIn, TodoController.deleteTodo);


### PR DESCRIPTION
# Description
- `getGroupTodos -> getGroup` 현재 그룹의 todo를 가져오는 로직보단 group의 전체 내용을 전달받는 편이 옳다고 판단
합의 후 groups의 속성 members와 todos의 전체정보를 보내주는 로직을 작성했고 `todoController`에서 `groupController`로 이동했습니다
- `mainController`에서 부족했던 Mongoose Id Validation을 구현했습니다
- 파일이동과 로직 변경에 따라 라우터를 변경하였습니다
- 현재 개발과정에서 불필요한 jwt의 expiration이 지정되어있어 제거했습니다

# Type of Change
- [ ]  버그 수정
- [ ]  새로운 기능 추가
- [x]  리팩토링
- [ ]  문서 업데이트

# Canban Link
기존의 [특정그룹의 todo 목록 가져오기](https://www.notion.so/vanillacoding/GET-Todo-eedfc794f9d44b0a88d863923dd66344)
# Check List
- [x]  나의 코드가 프로젝트의 코드 스타일을 따랐는가
- [x]  커밋하기 전에 자신의 코드를 점검했는가
- [x]  이해하기 어려운 코드에 대한 언급을 하였는가
- [x]  문서의 내용과 일치하는 작업을 했는가
- [x]  나의 코드가 새로운 문제를 발생시키진 않는가

# 기타 사항
