### PR TITLE
chore: Change authorization logic to verify chrome-extension user

### DIFF
--- a/middlewares/authorization.js
+++ b/middlewares/authorization.js
@@ -4,24 +4,34 @@ const User = require("../models/User");
 const catchAsync = require("../utils/catchAsync");
 
 const isLoggedIn = catchAsync(async (req, res, next) => {
-  const token = req.headers.authorization.split(" ")[1];
+  const verifier = req.headers?.authorization.split(" ")[0];
+  const token = req.headers?.authorization.split(" ")[1];
+  const email = req.headers?.email;
 
-  if (!token) {
-    return res.json({
-      result: "error",
-      error: {
-        message: "유효하지 않은 접근입니다.",
-        status: 400,
-      },
-    });
+  if (verifier === "Bearer" && token) {
+    const { id } = jwt.verify(token, process.env.SECRET_KEY);
+    const user = await User.findById(id).lean();
+
+    req.user = user;
+
+    return next();
   }
 
-  const { id } = jwt.verify(token, process.env.SECRET_KEY);
-  const user = await User.findById(id).lean();
+  if (verifier === "Extension" && token && jwt.verify(token, process.env.SECRET_KEY) === process.env.EXTENSION_KEY) {
+    const user = await User.findOne({ email }).lean();
 
-  req.user = user;
+    req.user = user;
 
-  return next();
+    return next();
+  }
+
+  return res.json({
+    result: "error",
+    error: {
+      message: "유효하지 않은 접근입니다.",
+      status: 400,
+    },
+  });
 });
 
 module.exports = isLoggedIn;


### PR DESCRIPTION
# Description
<img src="https://user-images.githubusercontent.com/93723399/173512601-b441da72-25d9-4c90-8137-0aae7c37b85f.png" width="700" />

크롬 익스텐션 사용자의 authorization을 위해 로직을 일부 변경했습니다.
우선 headers의 authorization을 split해서 나오는 값의 0번째 인덱스로 일반 웹사용자, 익스텐션 사용자를 구분하였고
1. 웹사용자가 토큰을 가지고 있을때와
2. 익스텐션사용자가 토큰을 가지고 있고, 토큰이 합당한 토큰일 때에만 유저정보와함께 next로 넘어가게 했습니다

에러를 response로 보내는 로직이 반복되는 것 같아 긍정 조건문을 위로 먼저 빼두고
어떠한 경우에도 속하지 않을 때에 마지막에 에러를 return 하도록 작성했습니다

# Type of Change
- [ ]  버그 수정
- [x]  새로운 기능 추가
- [ ]  리팩토링
- [ ]  문서 업데이트

# Canban Link
[BE 크롬 익스텐션](https://www.notion.so/vanillacoding/BE-9c683b4025ad457fa4dc157afd21d390)

# Check List
- [x]  나의 코드가 프로젝트의 코드 스타일을 따랐는가
- [x]  커밋하기 전에 자신의 코드를 점검했는가
- [x]  이해하기 어려운 코드에 대한 언급을 하였는가
- [x]  문서의 내용과 일치하는 작업을 했는가
- [x]  나의 코드가 새로운 문제를 발생시키진 않는가

# 기타 사항
