### PR TITLE
feat: addGroupMember in router & groupController

### DIFF
--- a/routes/group.js
+++ b/routes/group.js
@@ -9,6 +9,7 @@ const router = express.Router();
 router.get("/:groupId", isLoggedIn, groupController.getGroup);
 router.post("/", isLoggedIn, groupController.createGroup);
 router.patch("/:groupId", isLoggedIn, groupController.updateGroup);
+router.patch("/:groupId/addMember", isLoggedIn, groupController.updateGroupMember);
 router.delete("/:groupId", isLoggedIn, groupController.deleteGroup);
 
 router.post("/:groupId/todos", isLoggedIn, todoController.createTodo);


### PR DESCRIPTION
# Description

공유 URL을 통해 들어온 유저를 방에 추가하기 위한 로직을 추가했습니다.
- 로직 흐름
  1. URL을 통해 들어온 유저의 그룹에 해당 그룹이 있는지 확인합니다.
  2. 그룹이 없다면 User의 group, Group의 members에 각각의 그룹 아이디와 유저 아이디를 집어넣습니다.

그룹 멤버를 추가하는 로직을 작성하면서 그룹을 삭제하는 로직이 작동되지 않는 문제가 발견되어 리팩토링을 진행했습니다.
- 기존 로직 흐름
  1.  그룹 멤버 배열의 길이가 1이라면 그룹을 삭제합니다.
  2. 삭제한 그룹의 Todos 배열을 Todo에서 삭제합니다.
  3.  삭제한 그룹의 아이디를 User의 group에서 삭제합니다.
 
- 변경된 로직 흐름
  - 문제점 : 삭제하고 싶은 그룹에 멤버가 남아있다면 그룹을 삭제한 멤버만 삭제되고 그룹을 그대로 유지되어야하는데, 오로지 그룹 멤버가 1명 남았을 때, Group, User, Todo에서 전부 삭제되도록 로직을 작성해 문제가 되었습니다.
  1. 그룹 멤버 배열의 길이가 1이 아닌 경우 Group의 members에서 그룹을 삭제한 유저의 아이디를, User의 group에서 삭제한 그룹의 아이디를 삭제합니다.
  2. 그룹 멤버 배열의 길이가 1인 경우 기존 로직의 흐름과 같습니다.

# Type of Change
- [ ]  버그 수정
- [x]  새로운 기능 추가
- [x]  리팩토링
- [ ]  문서 업데이트

# Canban Link
[[FE/BE] Share - Group Member 추가](https://www.notion.so/vanillacoding/FE-BE-Share-Group-Member-d91a8c2e80ec495e89ae84831fd0803d)
…

# Check List
- [x]  나의 코드가 프로젝트의 코드 스타일을 따랐는가
- [x]  커밋하기 전에 자신의 코드를 점검했는가
- [x]  이해하기 어려운 코드에 대한 언급을 하였는가
- [x]  문서의 내용과 일치하는 작업을 했는가
- [x]  나의 코드가 새로운 문제를 발생시키진 않는가

# 기타 사항
